### PR TITLE
Handle degenerate forms of json emptiness

### DIFF
--- a/lib/json_record/json_field.rb
+++ b/lib/json_record/json_field.rb
@@ -35,6 +35,7 @@ module JsonRecord
       unless @record[@name].blank?
         json = @record[@name]
         json = Zlib::Inflate.inflate(json) if @compressed
+        json = "{}" if json == "''" || json == '""' 
         do_not_track_changes = Thread.current[:do_not_track_json_field_changes]
         Thread.current[:do_not_track_json_field_changes] = true
         begin

--- a/spec/serialized_spec.rb
+++ b/spec/serialized_spec.rb
@@ -147,6 +147,18 @@ describe JsonRecord::Serialized do
     model.value.should == 0
   end
   
+  it "uses default values if degenerate JSON is set" do
+    model = JsonRecord::Test::Model.new(:json => '')
+    model.value.should == 0
+    model = JsonRecord::Test::Model.new(:json => '""')
+    model.value.should == 0
+    model = JsonRecord::Test::Model.new(:json => "''")
+    model.value.should == 0
+    model = JsonRecord::Test::Model.new(:json => nil)
+    model.value.should == 0
+  end
+  
+  
   it "should initialize json attributes with blank values" do
     json_attributes = JsonRecord::Test::Model.new.attributes
     json_attributes.delete('id').should == nil
@@ -188,7 +200,7 @@ describe JsonRecord::Serialized do
     model_2.map["val2"] = 2
     model_2.map.should == {"val2" => 2}
   end
-  
+    
   it "should allow mass assignment of json attributes" do
     model = JsonRecord::Test::Model.new(:name => "test name", :string_field => "test string_field", :price => "1")
     model.name.should == "test name"


### PR DESCRIPTION
When the json is %q[""] or %q[''], json_record was barfing after parsing the json, expecting the decoded thing to be a hash already.  Fixed.
